### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/apps/http-server/package.json
+++ b/apps/http-server/package.json
@@ -27,6 +27,7 @@
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/apps/http-server/src/routes/roomRouter.ts
+++ b/apps/http-server/src/routes/roomRouter.ts
@@ -2,8 +2,16 @@ import express from 'express';
 import { authMiddleware } from '../middleware/middleware.js';
 import { CreateRoomSchema } from '@repo/common/index';
 import { prisma } from '@repo/db/index';
+import rateLimit from 'express-rate-limit';
 
 const roomRouter: express.Router = express.Router();
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+roomRouter.use(limiter);
 
 roomRouter.post('/create', authMiddleware, async (req, res) => {
     const parsedData = CreateRoomSchema.safeParse(req.body);


### PR DESCRIPTION
Potential fix for [https://github.com/ghagevaibhav/Chat-Room-App/security/code-scanning/4](https://github.com/ghagevaibhav/Chat-Room-App/security/code-scanning/4)

To fix the problem, we need to introduce rate limiting to the route handlers in the `roomRouter`. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure a rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the `roomRouter`.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `roomRouter` file.
3. Configure the rate limiter with the desired settings.
4. Apply the rate limiter to the `roomRouter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
